### PR TITLE
chore: bump gha-workflow-validator to 0.5.2

### DIFF
--- a/.github/workflows/gha-workflow-validation.yml
+++ b/.github/workflows/gha-workflow-validation.yml
@@ -21,6 +21,6 @@ jobs:
           persist-credentials: false
 
       - name: Run gha-workflow-validator action
-        uses: smartcontractkit/.github/actions/gha-workflow-validator@782f2ba4d8fa36a9d214b791b4938259875e1412 # gha-workflow-validator@0.5.0
+        uses: smartcontractkit/.github/actions/gha-workflow-validator@gha-workflow-validator/0.5.2
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Changes

Bump `gha-workflow-validator` to 0.5.2 - https://github.com/smartcontractkit/.github/releases/tag/gha-workflow-validator%2F0.5.2