### PR TITLE
Create workflow to fail job if PR contains certain label

### DIFF
--- a/.github/scripts/do-not-merge-block.js
+++ b/.github/scripts/do-not-merge-block.js
@@ -1,0 +1,31 @@
+/**
+ * Fails the workflow if any of the specified labels are present on the PR.
+ *
+ * Inputs (via environment):
+ *   FAIL_LABELS: comma-separated list of labels to check (default: "do-not-merge")
+ */
+
+module.exports = async ({ context, core }) => {
+  const failLabels = (process.env.FAIL_LABELS || "do-not-merge")
+    .split(",")
+    .map((l) => l.trim().toLowerCase())
+    .filter(Boolean);
+
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.info("This action is only applicable to pull requests.");
+    return;
+  }
+
+  const prLabels = (pr.labels || []).map((l) => l.name.toLowerCase());
+  const found = failLabels.find((label) => prLabels.includes(label));
+
+  if (found) {
+    const msg = `❌ This PR has a label that blocks merging: \`${found}\`.\nPlease remove the label to proceed.`;
+    core.summary.addRaw(msg);
+    core.setFailed(msg);
+    return;
+  }
+
+  core.info(`No blocking labels found. Blocking labels checked: [${failLabels.join(", ")}]`);
+};

--- a/.github/workflows/do-not-merge-block.yml
+++ b/.github/workflows/do-not-merge-block.yml
@@ -1,0 +1,39 @@
+###
+# This workflow fails if a PR has a blocking label (e.g., "do-not-merge").
+#
+# To customize blocking labels, set the FAIL_LABELS variable (comma-separated).
+#     Default: "do-not-merge"
+#
+# To set the variable, you can use the GitHub CLI:
+#     gh variable set FAIL_LABELS --body "do-not-merge,dnm"
+###
+
+name: Do Not Merge Blocker
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  do-not-merge-block:
+    name: Do Not Merge Block
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    # Skip on merge group events
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if blocking label present
+        uses: actions/github-script@v7
+        env:
+          FAIL_LABELS: ${{ vars.DO_NOT_MERGE_LABELS || 'do-not-merge' }}
+        with:
+          script: |
+            const script = require('./.github/scripts/do-not-merge-block.js');
+            await script({ context, core });

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 120,
+  "proseWrap": "always",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
+}


### PR DESCRIPTION
Enables us to set `do-not-merege` (default) labels on PR's and fail the job in order to block PR's with these labels from being merged.