### PR TITLE
feat(ci): codeowners enforcement workflow

### DIFF
--- a/.github/workflows/codeowners-enforcement.yml
+++ b/.github/workflows/codeowners-enforcement.yml
@@ -1,0 +1,80 @@
+name: "CodeOwners Enforcement"
+
+on:
+  pull_request:
+
+jobs:
+  enforce-codeowners:
+    name: "Enforce"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      COMMENT_FINGERPRINT: '<!-- chainlink-codeowners-enforcement -->'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check for CODEOWNERS file
+        id: codeowners-file
+        run: |
+          # check at ./CODEOWNERS and .github/CODEOWNERS
+          if [ ! -f CODEOWNERS ] && [ ! -f .github/CODEOWNERS ]; then
+            echo "CODEOWNERS file not found"
+            echo "found=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "found=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find PR Comment
+        id: find-comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: ${{ env.COMMENT_FINGERPRINT }}
+
+      - name: Upsert comment if no CODEOWNERS exists
+        if: ${{ steps.codeowners-file.outputs.found == 'false' }}
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: 'replace'
+          body: |
+            ### No CODEOWNERS file detected - @${{ github.actor }}
+
+            This repository doesn't contain a CODEOWNERS file. Please add one at one of the following paths:
+            1. `CODEOWNERS` (root of repository)
+            2. `.github/CODEOWNERS`
+
+            If this repository is owned/used by a single team the default entry for a CODEOWNERS would be:
+
+            ```
+            * @smartcontractkit/<your team>
+            ```
+
+            For more information see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+            ${{ env.COMMENT_FINGERPRINT }}
+
+      - name: Update comment if CODEOWNERS was added
+        if: ${{ steps.codeowners-file.outputs.found == 'true' && steps.find-comment.outputs.comment-id != '' }}
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: 'replace'
+          body: |
+            Thank you for adding a CODEOWNERS file - @${{ github.actor }}.
+
+            ${{ env.COMMENT_FINGERPRINT }}
+
+      - name: Fail if no CODEOWNERS file is found
+        if: ${{ steps.codeowners-file.outputs.found == 'false' }}
+        run: |
+          echo "::error::No CODEOWNERS file found."
+          exit 1

--- a/.github/workflows/codeowners-enforcement.yml
+++ b/.github/workflows/codeowners-enforcement.yml
@@ -25,9 +25,9 @@ jobs:
           # check at ./CODEOWNERS and .github/CODEOWNERS
           if [ ! -f CODEOWNERS ] && [ ! -f .github/CODEOWNERS ]; then
             echo "CODEOWNERS file not found"
-            echo "found=true" | tee -a "$GITHUB_OUTPUT"
-          else
             echo "found=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "found=true" | tee -a "$GITHUB_OUTPUT"
           fi
 
       - name: Find PR Comment

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Uses [`gha-workflow-validator`](https://github.com/smartcontractkit/.github/tree
 Uses [patrickhuie19/codeowners-validator](https://github.com/patrickhuie19/codeowners-validator/) action.
 * Validates the contents of a CODEOWNERS file when it is modified. Enforces certain criteria to ensure healthy CODEOWNERS.
 
+### CODEOWNERS Enforcement
+
+Enforces that every repository has a CODEOWNERS file.
 
 ## Help
 


### PR DESCRIPTION
Adds a CODEOWNERS enforcement workflow.

This workflow:
1. Checks out repo (at PR branch)
2. Checks if there's a CODEOWNERS file at `.github/CODEOWNERS` or in the root of the repository
3. Attempts to find a PR comment (html comment fingerprint)
4. If no CODEOWNERS file is found - upsert the comment
5. If CODEOWNERS file is found:
   - If no previous comment - do nothing
   - If previous comment - edit to a thank you
6. If no CODEOWNERS found - fail the action

### Testing

- https://github.com/smartcontractkit/releng-test/pull/133

This PR:
- Initial commit (fail): https://github.com/smartcontractkit/gha-org-workflows/actions/runs/17246297685/job/48936695738?pr=13
  - See below comment history
- Un-reversed booleans (success): https://github.com/smartcontractkit/gha-org-workflows/actions/runs/17246339976/job/48936851174?pr=13
  - https://github.com/smartcontractkit/gha-org-workflows/pull/13#issuecomment-3225158386

---

DX-1647