### PR TITLE
chore(ci): bump gha-workflow-validator to v0.5.3

### DIFF
--- a/.github/workflows/gha-workflow-validation.yml
+++ b/.github/workflows/gha-workflow-validation.yml
@@ -21,6 +21,6 @@ jobs:
           persist-credentials: false
 
       - name: Run gha-workflow-validator action
-        uses: smartcontractkit/.github/actions/gha-workflow-validator@gha-workflow-validator/0.5.2
+        uses: smartcontractkit/.github/actions/gha-workflow-validator@gha-workflow-validator/0.5.3
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Changes

Bump `gha-workflow-validator` to ` 0.5.3`.
  - https://github.com/smartcontractkit/.github/releases/tag/gha-workflow-validator%2F0.5.3
  - https://github.com/smartcontractkit/.github/pull/1181 