### PR TITLE
feat(ci): codeowners-enforcement use new sanity-check action

### DIFF
--- a/.github/workflows/codeowners-enforcement.yml
+++ b/.github/workflows/codeowners-enforcement.yml
@@ -8,73 +8,12 @@ jobs:
     name: "Enforce"
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
-    env:
-      COMMENT_FINGERPRINT: '<!-- chainlink-codeowners-enforcement -->'
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-          persist-credentials: false
+      - name: CODEOWNERS Sanity Check
+        uses: smartcontractkit/.github/actions/codeowners-sanity-check@codeowners-sanity-check/v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Check for CODEOWNERS file
-        id: codeowners-file
-        run: |
-          # check at ./CODEOWNERS and .github/CODEOWNERS
-          if [ ! -f CODEOWNERS ] && [ ! -f .github/CODEOWNERS ]; then
-            echo "CODEOWNERS file not found"
-            echo "found=false" | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "found=true" | tee -a "$GITHUB_OUTPUT"
-          fi
-
-      - name: Find PR Comment
-        id: find-comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: ${{ env.COMMENT_FINGERPRINT }}
-
-      - name: Upsert comment if no CODEOWNERS exists
-        if: ${{ steps.codeowners-file.outputs.found == 'false' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: 'replace'
-          body: |
-            ### No CODEOWNERS file detected - @${{ github.actor }}
-
-            This repository doesn't contain a CODEOWNERS file. Please add one at one of the following paths:
-            1. `CODEOWNERS` (root of repository)
-            2. `.github/CODEOWNERS`
-
-            If this repository is owned/used by a single team the default entry for a CODEOWNERS would be:
-
-            ```
-            * @smartcontractkit/<your team>
-            ```
-
-            For more information see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-            ${{ env.COMMENT_FINGERPRINT }}
-
-      - name: Update comment if CODEOWNERS was added
-        if: ${{ steps.codeowners-file.outputs.found == 'true' && steps.find-comment.outputs.comment-id != '' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: 'replace'
-          body: |
-            Thank you for adding a CODEOWNERS file - @${{ github.actor }}.
-
-            ${{ env.COMMENT_FINGERPRINT }}
-
-      - name: Fail if no CODEOWNERS file is found
-        if: ${{ steps.codeowners-file.outputs.found == 'false' }}
-        run: |
-          echo "::error::No CODEOWNERS file found."
-          exit 1


### PR DESCRIPTION
### Changes

Make `codeowners-enforcement` workflow use https://github.com/smartcontractkit/.github/tree/main/actions/codeowners-sanity-check instead.

This allows us to:
1. Not checkout the repo
2. Actually perform simple validation on the CODEOWNERS file

---

DX-1647