### PR TITLE
chore: bump go-mod-validator to v1

### DIFF
--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate go.mod
-        uses: smartcontractkit/.github/apps/go-mod-validator@go-mod-validator/0.5.2
+        uses: smartcontractkit/.github/apps/go-mod-validator@go-mod-validator/v1


### PR DESCRIPTION
### Changes

Bumps `go-mod-validator` to [`v1`](https://github.com/smartcontractkit/.github/releases/tag/go-mod-validator%2Fv1).

### Notes

This includes changes:
- https://github.com/smartcontractkit/.github/commit/68d1f0acc43b056f976ad6f472799ebf4e8d35d5
- https://github.com/smartcontractkit/.github/commit/db46e40e236e0ed4cafb6601d21f6a92b79e4fc8

---

DX-1919
